### PR TITLE
Lazy node health check when loading the page

### DIFF
--- a/server/handlers/claims.ts
+++ b/server/handlers/claims.ts
@@ -18,8 +18,10 @@ export const claimsHandler = (appConfig: IApp) => {
     return async (req: any, res: any, next: any) => {
         const { recipient, amount, selectedMosaics } = req.body;
 
-        const { repositoryFactory, config, faucetAccount } = appConfig;
-
+        const { repositoryFactory, config } = appConfig;
+        const faucetAccount = await appConfig.faucetAccount;
+        const networkType = await appConfig.networkType;
+        const generationHash = await appConfig.networkGenerationHash;
         console.debug({ recipient, amount, selectedMosaics });
 
         if (typeof recipient !== 'string' || recipient.length !== 39) throw new Error(`recipient address invalid.`);
@@ -30,10 +32,7 @@ export const claimsHandler = (appConfig: IApp) => {
 
         const mosaicIds = selectedMosaics.map((mosaic) => new MosaicId(mosaic));
         const recipientAddress: Address = Address.createFromRawAddress(recipient);
-        const networkType = await repositoryFactory.getNetworkType().toPromise();
-        const generationHash = await repositoryFactory.getGenerationHash().toPromise();
-        const feeMultiplier = await (await repositoryFactory.createNetworkRepository().getTransactionFees().toPromise())
-            .highestFeeMultiplier;
+        const feeMultiplier = (await repositoryFactory.createNetworkRepository().getTransactionFees().toPromise()).highestFeeMultiplier;
 
         forkJoin(
             repositoryFactory.createNamespaceRepository().getMosaicsNames(mosaicIds),

--- a/server/handlers/claims.ts
+++ b/server/handlers/claims.ts
@@ -18,13 +18,13 @@ export const claimsHandler = (appConfig: IApp) => {
     return async (req: any, res: any, next: any) => {
         const { recipient, amount, selectedMosaics } = req.body;
 
+        if (typeof recipient !== 'string' || recipient.length !== 39) throw new Error(`recipient address invalid.`);
+
         const { repositoryFactory, config } = appConfig;
         const faucetAccount = await appConfig.faucetAccount;
         const networkType = await appConfig.networkType;
         const generationHash = await appConfig.networkGenerationHash;
         console.debug({ recipient, amount, selectedMosaics });
-
-        if (typeof recipient !== 'string' || recipient.length !== 39) throw new Error(`recipient address invalid.`);
 
         if (typeof amount !== 'number') throw new Error(`amount format invalid.`);
 


### PR DESCRIPTION
Faucet will do a health check each time the config is requested by the client instead of memorizing the boot value. If not, the user may think the node is down when it was recovered (or the other way around). 

Currently, if the node is down on boot, the faucet doesn't stop, just show the error to the user.

The user would still see the "API node is offline." but it will represent the real node health.

Loading network type and generation hash from the App.
Fixed mosaic id resolution (invalid instance of)